### PR TITLE
Potential fix for code scanning alert no. 2: Clear-text logging of sensitive information

### DIFF
--- a/example/internal/server/server.go
+++ b/example/internal/server/server.go
@@ -15,7 +15,7 @@ func Start() {
 	if err := singleton.GetInto("global-config", &appConfig); err != nil {
 		panic(err)
 	}
-	fmt.Printf("Retrieved appConfig from singleton. APIKey is: %s\n", appConfig.APIKey)
+	fmt.Println("Retrieved appConfig from singleton. APIKey is successfully retrieved.")
 
 	time.Sleep(5000 * time.Millisecond)
 	fmt.Println("Stopping server")


### PR DESCRIPTION
Potential fix for [https://github.com/elnerd/go-singleton/security/code-scanning/2](https://github.com/elnerd/go-singleton/security/code-scanning/2)

To fix the problem, we need to ensure that the sensitive information (API key) is not logged in clear text. The best way to fix this without changing existing functionality is to remove the API key from the log message or obfuscate it. We will modify the log message to exclude the API key and instead log a message indicating that the API key was retrieved without revealing its value.

We will make changes to the file `example/internal/server/server.go` on line 18 to remove the API key from the log message.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
